### PR TITLE
v4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = lib/aegis
 	url = https://github.com/geniiii/aegis.cpp.git
 	branch = msvc-fix
+[submodule "lib/robin_hood"]
+	path = lib/robin_hood
+	url = https://github.com/martinus/robin-hood-hashing.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.12...3.15)
 
-set(aisaka_SOVERSION 3)
-set(aisaka_VERSION_MAJOR 3)
+set(aisaka_SOVERSION 4)
+set(aisaka_VERSION_MAJOR 4)
 set(aisaka_VERSION_MINOR 0)
-set(aisaka_VERSION_PATCH 2)
-set(aisaka_VERSION "${aisaka_VERSION_MAJOR}.${aisaka_VERSION_MINOR}.${aisaka_VERSION_PATCH}")
+set(aisaka_VERSION_PATCH 0)
+set(aisaka_VERSION ${aisaka_VERSION_MAJOR}.${aisaka_VERSION_MINOR}.${aisaka_VERSION_PATCH})
 
 project(
   aisaka
@@ -52,6 +52,7 @@ aisaka_option(USE_SYSTEM_AEGIS "Whether to look for an already installed aegis.c
 aisaka_option(GENERATE_DOCS "Whether to generate documentation or not" ON)
 
 find_package(fifo_map REQUIRED)
+find_package(robin_hood REQUIRED)
 
 if(USE_SYSTEM_AEGIS)
 	find_package(Aegis)
@@ -86,7 +87,8 @@ install(DIRECTORY ${aisaka_INCLUDE_BUILD_DIR}
 install(
   FILES ${aisaka_CMAKE_PROJECT_CONFIG_FILE} ${aisaka_CMAKE_VERSION_CONFIG_FILE}
         ${CMAKE_CURRENT_LIST_DIR}/cmake/Findfifo_map.cmake
-		${CMAKE_CURRENT_LIST_DIR}/cmake/FindSphinx.cmake		
+		${CMAKE_CURRENT_LIST_DIR}/cmake/FindSphinx.cmake
+		${CMAKE_CURRENT_LIST_DIR}/cmake/Findphmap.cmake				
   DESTINATION ${aisaka_CONFIG_INSTALL_DIR})
 
 export(PACKAGE ${PROJECT_NAME})

--- a/cmake/Findrobin_hood.cmake
+++ b/cmake/Findrobin_hood.cmake
@@ -1,0 +1,23 @@
+find_path(robin_hood_INCLUDE_DIR NAMES "robin_hood.h" PATHS "${CMAKE_CURRENT_SOURCE_DIR}/lib/robin_hood/src/include/")
+if(robin_hood_INCLUDE_DIR STREQUAL "robin_hood_INCLUDE_DIR-NOTFOUND")
+	message(FATAL_ERROR "Could not find robin_hood.")
+	set(robin_hood_FOUND FALSE)
+endif()
+
+set(robin_hood_FOUND TRUE)
+
+if(robin_hood_FOUND)
+	include(FindPackageHandleStandardArgs)
+	find_package_handle_standard_args(robin_hood
+		REQUIRED_VARS robin_hood_INCLUDE_DIR
+		FOUND_VAR robin_hood_FOUND
+		FAIL_MESSAGE "Could not find robin_hood.")
+
+	if(NOT TARGET robin_hood)
+		add_library(robin_hood INTERFACE IMPORTED)
+		set_target_properties(robin_hood PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${robin_hood_INCLUDE_DIR})
+	endif()
+
+    mark_as_advanced(robin_hood_INCLUDE_DIR)
+endif()

--- a/include/aisaka/Bot.hpp
+++ b/include/aisaka/Bot.hpp
@@ -2,7 +2,6 @@
 
 #include <aegis.hpp>
 #include <aisaka/command/Commands.hpp>
-#include <unordered_map>
 
 namespace Aisaka {
 class Bot {
@@ -14,11 +13,11 @@ class Bot {
 	 * @param owner_id The ID of the bot's owner. If not passed, the owner ID will be set to -1.
 	 */
 	Bot(const std::string_view default_prefix, const std::string_view name,
-		std::optional<const int64_t> owner_id)
+		const int64_t owner_id = -1)
 		: _core(aegis::core(spdlog::level::trace)),
 		  _default_prefix(default_prefix),
 		  _name(name),
-		  _owner_id(owner_id.value_or(-1)) {
+		  _owner_id(owner_id) {
 		this->_core.set_on_message_create(std::bind(
 			&Aisaka::Bot::on_message_create, this, std::placeholders::_1));
 	}
@@ -42,12 +41,11 @@ class Bot {
 	virtual void on_message_create(aegis::gateway::events::message_create) {}
 
    private:
+	Aisaka::Commands<> _commands;
 	aegis::core _core;
 
 	std::string _default_prefix;
 	std::string _name;
 	int64_t _owner_id;
-
-	Aisaka::Commands<> _commands;
 };
 }  // namespace Aisaka

--- a/include/aisaka/Version.hpp
+++ b/include/aisaka/Version.hpp
@@ -7,16 +7,16 @@
 /// The library's version number as a dotted triplet string.
 /**
  * @code
- * 3.0.2
+ * 4.0.0
  * @endcode
  */
-#define AISAKA_VERSION "3.0.2"
+#define AISAKA_VERSION "4.0.0"
 
 /// The library's major version number.
-#define AISAKA_VERSION_MAJOR "3"
+#define AISAKA_VERSION_MAJOR "4"
 
 /// The library's minor version number.
 #define AISAKA_VERSION_MINOR "0"
 
 /// The library's patch number.
-#define AISAKA_VERSION_PATCH "2"
+#define AISAKA_VERSION_PATCH "0"

--- a/include/aisaka/command/Command.hpp
+++ b/include/aisaka/command/Command.hpp
@@ -41,7 +41,7 @@ class Command {
 	using Function =
 		std::function<void(aegis::gateway::events::message_create& obj,
 						   T& client, const std::deque<std::string>& params,
-						   const std::string& command_prefix)>;
+						   const std::string_view command_prefix)>;
 
 	GETTER_SETTER(name, const std::string&)
 	GETTER_SETTER(category, const Aisaka::Category<T>&)

--- a/include/aisaka/command/Commands.hpp
+++ b/include/aisaka/command/Commands.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <robin_hood.h>
+
 #include <aisaka/command/Command.hpp>
 #include <aisaka/command/categories/Category.hpp>
 #include <fifo_map.hpp>
@@ -9,9 +11,9 @@ template <class T>
 class Commands {
    public:
 	/// All of the commands that have been added, with the key being the name of each one.
-	nlohmann::fifo_map<std::string, Aisaka::Command<T>> all;
+	robin_hood::unordered_map<std::string, Aisaka::Command<T>> all;
 	/// All of the categories that have been added, with the key being the name of each one.
-	std::unordered_map<std::string, Aisaka::Category<T>> categories;
+	robin_hood::unordered_map<std::string, Aisaka::Category<T>> categories;
 
 	/// Adds a command and its aliases.
 	/**
@@ -50,8 +52,8 @@ class Commands {
 	 * @return If no command was found, std::nullopt; if one *was* found, the command itself.
 	 */
 	const std::optional<Aisaka::Command<T>> find_command(
-		const std::string_view command_name) const {
-		const auto& command = all.find(std::string{command_name});
+		const std::string& command_name) const {
+		const auto& command = all.find(command_name);
 		if (command != all.end()) {
 			return (*command).second;
 		}
@@ -64,8 +66,8 @@ class Commands {
 	 * @return If no category was found, return std::nullopt; if one *was* found, the category itself.
 	 */
 	const std::optional<Aisaka::Category<T>> find_category(
-		const std::string_view category_name) const {
-		const auto& category = categories.find(std::string{category_name});
+		const std::string& category_name) const {
+		const auto& category = categories.find(category_name);
 		if (category != categories.end()) {
 			return (*categories).second;
 		}

--- a/include/aisaka/util/String.hpp
+++ b/include/aisaka/util/String.hpp
@@ -22,8 +22,6 @@ class String {
 
 	static std::deque<std::string> split(const std::string_view source,
 										 const std::string_view delim);
-	static std::deque<std::string> split_command(const std::string_view source,
-												 const std::string_view prefix);
 	static std::string to_lower(const std::string_view);
 };
 }  // namespace Aisaka::Util

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,11 +21,13 @@ add_library(aisaka::aisaka ALIAS aisaka)
 target_include_directories(
   aisaka
   PUBLIC $<BUILD_INTERFACE:${aisaka_SOURCE_DIR}/include>
-         $<BUILD_INTERFACE:${Aegis_INCLUDE_DIRS}> $<INSTALL_INTERFACE:include>
+		 $<INSTALL_INTERFACE:include>
+         $<BUILD_INTERFACE:${Aegis_INCLUDE_DIRS}>
          ${LIBMONGOCXX_INCLUDE_DIRS})
 
-target_link_libraries(aisaka PUBLIC fifo_map ${Aegis_LIBRARIES}
-                                    ${LIBMONGOCXX_LIBRARIES})
+target_link_libraries(aisaka PUBLIC fifo_map robin_hood
+									${Aegis_LIBRARIES}
+									${LIBMONGOCXX_LIBRARIES})
 
 target_compile_definitions(aisaka PUBLIC ${LIBMONGOCXX_DEFINITIONS})
 

--- a/src/util/String.cpp
+++ b/src/util/String.cpp
@@ -13,23 +13,17 @@ std::deque<std::string> Aisaka::Util::String::split(
 		second = std::find_first_of(first, last, std::cbegin(delim),
 									std::cend(delim));
 
-		if (first != second)
+		if (first != second) {
 			output.emplace_back(first, second - first);
+		}
 	}
 
 	return output;
 }
 
-std::deque<std::string> Aisaka::Util::String::split_command(
-	const std::string_view source, const std::string_view prefix) {
-	auto arguments = Aisaka::Util::String::split(source, " ");
-	arguments.push_front(prefix.data());
-
-	return arguments;
-}
-
 std::string Aisaka::Util::String::to_lower(const std::string_view source) {
-	std::string string_lower{source};
+	std::string string_lower(source);
+
 	std::transform(string_lower.begin(), string_lower.end(),
 				   string_lower.begin(),
 				   [](unsigned char c) { return std::tolower(c); });


### PR DESCRIPTION
- pass `std::string_view` as prefix instead of `std::string&`
there was no real point in passing `std::string&`
- use robin_hood::unordered_map instead of std::unordered_map
this should hopefully improve performance and memory usage, even if not by much
- `Aisaka::Commands::find_command`/`find_category` now take `std::string&`
the reason being that passing `std::string_view` required me to construct a string either way
- remove `Aisaka::Util::String::split_command`
was a leftover from when aisaka handled commands
- other small changes